### PR TITLE
Added missing property to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Watch| If set to true, the hot reload is enabled
 BaseName| Is the root template name, e.g "base", "hot" etc
 Dir| The directory in which you keep your templates
 FilesExtension| Supported file extensions. These are the ones parsed in the template.
+Funcs| (optional) A map of names to functions that can be used inside your templates. ([more information](https://golang.org/pkg/text/template/#FuncMap))
+
 
 
 # Contributing


### PR DESCRIPTION
I had to look at the (admittedly very nice) code to see if hot supported funcsmap so I added it to the configuration table in the readme
