### PR TITLE
Test timing + log in config

### DIFF
--- a/hot.go
+++ b/hot.go
@@ -89,7 +89,7 @@ func (t *Template) Init() {
 				select {
 				case <-c:
 					watcher.Close()
-					fmt.Println("shutting down hot templates... done")
+					fmt.Fprintf(t.Out,"shutting down hot templates... done")
 					os.Exit(0)
 				case evt := <-watcher.Events:
 					fmt.Fprintf(t.Out, "%s:  reloading... \n", evt.String())

--- a/hot.go
+++ b/hot.go
@@ -22,6 +22,7 @@ type Config struct {
 	LeftDelim      string
 	RightDelim     string
 	FilesExtension []string
+	Log            io.Writer
 }
 
 type Template struct {
@@ -47,6 +48,9 @@ func New(cfg *Config) (*Template, error) {
 		tpl: tmpl,
 		cfg: cfg,
 		Out: os.Stdout,
+	}
+	if cfg.Log != nil {
+		tpl.Out = cfg.Log
 	}
 	tpl.Init()
 	err := tpl.Load(cfg.Dir)

--- a/hot_test.go
+++ b/hot_test.go
@@ -13,10 +13,10 @@ func testHot(conf *Config, t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func(w *sync.WaitGroup) {
+		defer w.Done()
 		tpl, err := New(conf)
 		if err != nil {
 			t.Error(err)
-			w.Done()
 			return
 		}
 		body := "hello {{.Name}}"
@@ -24,7 +24,6 @@ func testHot(conf *Config, t *testing.T) {
 		err = ioutil.WriteFile(name, []byte(body), 0600)
 		if err != nil {
 			t.Error(err)
-			w.Done()
 			return
 		}
 		time.Sleep(time.Second)
@@ -35,14 +34,12 @@ func testHot(conf *Config, t *testing.T) {
 		err = tpl.Execute(buf, "hello.tpl", data)
 		if err != nil {
 			t.Error(err)
-			w.Done()
 			return
 		}
 		message := "hello gernest"
 		if buf.String() != message {
-			t.Errorf("expcted %s got %s", message, buf.String())
+			t.Errorf("expected %s got %s", message, buf.String())
 		}
-		w.Done()
 	}(&wg)
 	wg.Wait()
 }


### PR DESCRIPTION
I had issues with the goroutine in Init: Init finished before watching files was complete, which led to timing issues during tests. I fixed this by initializing watch of files synchronously.

I also added log to the config, which allows hiding the initial loading messages.
