### PR TITLE
changed Init to only watch top level folder

### DIFF
--- a/hot.go
+++ b/hot.go
@@ -63,16 +63,8 @@ func (t *Template) Init() {
 		}
 		t.closeChannel = make(chan bool, 1)
 
-		err = filepath.Walk(t.cfg.Dir, func(fPath string, info os.FileInfo, ferr error) error {
-			if ferr != nil {
-				return ferr
-			}
-			if info.IsDir() {
-				fmt.Fprintln(t.Out, "start watching ", fPath)
-				return watcher.Add(fPath)
-			}
-			return nil
-		})
+		fmt.Fprintln(t.Out, "start watching ", t.cfg.Dir)
+		err = watcher.Add(t.cfg.Dir)
 		if err != nil {
 			watcher.Close()
 			fmt.Fprintln(t.Out, err)


### PR DESCRIPTION
Init function can only watch for one level deep inside a directory. Since Load will only load templates from first level, there is no need to watch for nested directories.